### PR TITLE
A few tweaks to get SshClient running on macOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,9 @@ import PackageDescription
 
 let package = Package(
     name: "SshClient",
+    platforms: [
+        .macOS(.v10_15),
+    ],
     products: [
         .library(
             name: "SshClient",

--- a/Sources/SshClient/CommandLinePasswordPrompt.swift
+++ b/Sources/SshClient/CommandLinePasswordPrompt.swift
@@ -1,5 +1,11 @@
+// Linux
 #if canImport(Glibc)
 import Glibc
+#endif
+
+// macOS
+#if canImport(Darwin)
+import Darwin
 #endif
 
 /// Command line password prompt.

--- a/Sources/ssh-execute/SshExecute.swift
+++ b/Sources/ssh-execute/SshExecute.swift
@@ -1,4 +1,13 @@
+// Linux
+#if canImport(Glibc)
 import Glibc
+#endif
+
+// macOS
+#if canImport(Darwin)
+import Darwin
+#endif
+
 import ArgumentParser
 import SshClient
 


### PR DESCRIPTION
Today I was playing around and decided to try to compile the client library on my MacBook Air (M1 chip). I found a few things that needed to change in order for it to build, and the ssh-execute demo to run:

 - Change minimum macOS version to 10.15. The swift-nio-ssh library requires 10.15, which means that SshClient must also require at least 10.15 to build.
 - Added some imports for the Darwin library under macOS. The ssh-execute sample runs fine in macOS 12.3.